### PR TITLE
chnaged #fff to #0b6623

### DIFF
--- a/client/src/main/resources/sass/dark.scss
+++ b/client/src/main/resources/sass/dark.scss
@@ -35,7 +35,7 @@ $switcher-show-color: $console-text-color;
 
 // Snippets
 $snippets-background: #15414c;
-$snippets-text-color: #fff;
+$snippets-text-color: #0b6623;
 $snippets-update-color: #859900;
 $snippets-line-color: #859900;
 $snippet-background-color: #073642;


### PR DESCRIPTION
this could be a weird bug because #fff in dark mode blurs out the text "different configuration" making it unreadable except in light mode.

you can verify this by opening scastie --> change to dark mode  and click "up" which is the last option at the bottom left of the screen.

Before
![des](https://user-images.githubusercontent.com/19264390/122164263-6b7cd680-ce6e-11eb-8b83-ff0d0b3a83a3.PNG)


After

![des2](https://user-images.githubusercontent.com/19264390/122164287-75063e80-ce6e-11eb-91fa-42d7ab289176.PNG)

